### PR TITLE
Feature/新增結帳訂單流程

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -1,6 +1,6 @@
 class API < Grape::API
   prefix :api
   format :json
-  mount Courses::V1
+  mount CoursesAPI::V1
   mount APILogin
 end

--- a/app/api/courses_api/v1.rb
+++ b/app/api/courses_api/v1.rb
@@ -1,4 +1,4 @@
-module Courses
+module CoursesAPI
   class V1 < Grape::API
     helpers ::APIHelper::AuthenticationHelper
     before { authenticate! }

--- a/app/form/orders/checkout_form.rb
+++ b/app/form/orders/checkout_form.rb
@@ -1,0 +1,53 @@
+module Orders 
+  class CheckoutForm 
+    include ActiveModel::Model
+    attr_accessor :user, :course
+    validates :user, :course, presence: true
+    validate :course_state
+    validate :duplicate_course
+    
+    def initialize(user: , course:)
+      @user = user
+      @course = course
+    end
+
+    def save!
+      return false unless valid?
+
+      ActiveRecord::Base.transaction do
+        place_order
+        checkout_order
+        @order.fulfill!
+
+        @order
+      end
+      # @todo rescue payment failed
+    end
+
+    private
+
+    def place_order
+      @order = @user.orders.create(course: @course)
+    end
+
+    def checkout_order
+      @payment = @order.payments.create(amount: @order.amount)
+      @payment.charge! 
+      # @note: raise error if payment failed,
+      #   and turn payment state to failed
+      @order.pay!
+    end
+
+    def course_state
+      return if @course.launched?
+
+      errors.add(:course, "is dlished.")
+    end
+
+    def duplicate_course
+      return unless @user.available_courses.include?(@course)
+
+      errors.add(:coures, "has been purchased and still available.")
+    end
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -16,4 +16,9 @@ class Payment < ApplicationRecord
   end
 
   monetize :amount_cents
+
+  def charge!
+    # @note: Impelement payment flow here 
+    succeed!
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   has_secure_token :access_token
 
   has_many :orders
+  has_many :course_available_orders, ->{ course_available }, class_name: 'Order'
+  has_many :available_courses, through: :course_available_orders, source: :course
 
   enum role: { normal: 0, admin: 1 }
 

--- a/app/services/courses/checkout_order_service.rb
+++ b/app/services/courses/checkout_order_service.rb
@@ -1,0 +1,5 @@
+module Courses
+  class ChectoutOrderService
+  end
+end
+

--- a/app/services/courses/checkout_order_service.rb
+++ b/app/services/courses/checkout_order_service.rb
@@ -1,5 +1,0 @@
-module Courses
-  class ChectoutOrderService
-  end
-end
-

--- a/db/migrate/20201016095648_remove_start_at_on_order.rb
+++ b/db/migrate/20201016095648_remove_start_at_on_order.rb
@@ -1,0 +1,5 @@
+class RemoveStartAtOnOrder < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :orders, :start_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_15_161140) do
+ActiveRecord::Schema.define(version: 2020_10_16_095648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,7 +38,6 @@ ActiveRecord::Schema.define(version: 2020_10_15_161140) do
 
   create_table "orders", force: :cascade do |t|
     t.integer "state", null: false
-    t.datetime "start_at"
     t.datetime "end_at"
     t.integer "amount_cents", null: false
     t.string "amount_currency", default: "NTD", null: false

--- a/spec/api/courses_api/v1_spec.rb
+++ b/spec/api/courses_api/v1_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Courses::V1 do
+describe CoursesAPI::V1 do
   let(:user) { create(:user, :with_valid_access_token) }
   let(:access_token) { user.access_token }
   let(:headers) do 

--- a/spec/api/courses_api/v1_spec.rb
+++ b/spec/api/courses_api/v1_spec.rb
@@ -17,7 +17,7 @@ describe CoursesAPI::V1 do
     it do
       get '/api/v1/courses', headers: headers
       expect(JSON.parse( response.body ).first).to include({"title"=>"Sample Course",
-                                                            "status"=>"delisted",
+                                                            "status"=>"launched",
                                                             "slug"=>"sample-course",
                                                             "duration"=>7})
     end

--- a/spec/factories/coures.rb
+++ b/spec/factories/coures.rb
@@ -4,7 +4,10 @@ FactoryBot.define do
     slug { title.gsub(/\s|_/, '-').downcase }
     duration { 7 }
     description { 'This is Sample Course' }
+    status { :launched }
     price { 9527 }
     category
+
+    initialize_with { Course.find_or_create_by(slug: slug)}
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :order do
+    user
+    course 
+
+    trait :fulfilled do
+      after(:create) do |order|
+        order.pay!
+        order.fulfill!
+      end
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     email { 'user@example.com' }
     password { '123456' }
     access_token_expired_at { nil }
+    initialize_with { User.find_or_create_by(email: email)}
+
     trait :with_valid_access_token do
       after(:create) do |user|
         user.update(access_token_expired_at: 7.days.after)

--- a/spec/form/orders/checkout_form_spec.rb
+++ b/spec/form/orders/checkout_form_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe Orders::CheckoutForm do
+  let(:user) { create :user }
+  let(:course) { create :course }
+  let(:form) { described_class.new(user: user, course: course) }
+  
+  describe '#valid?' do
+    subject { form.valid? }
+    it { is_expected.to be(true) }
+    
+    context 'when course is delisted' do
+      before { course.delisted! }
+
+      it { is_expected.to be(false) }
+    end
+    context 'when course is duplicated' do
+      before { create(:order, :fulfilled, user: user, course: course) }
+
+      it { is_expected.to be(false) }
+      it 'has error message' do
+        form.valid?
+        expect(form.errors.full_messages).to include("Coures has been purchased and still available.")
+      end
+    end
+
+  end
+
+  describe '#save!' do
+    subject { form.save! }
+    it { is_expected.to be_truthy }
+    it { is_expected.to be_an Order }
+    
+    it 'create an order' do
+      expect{ subject }.to change{ user.orders.count }.from(0).to(1)
+    end
+
+    it { is_expected.to be_fulfilled }
+  end
+end

--- a/spec/model/order_spec.rb
+++ b/spec/model/order_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe Order do
+  let(:user) { create :user }
+  let(:course) { create :course }
+  let(:order) { create(:order, user: user, course: course) }
+
+  describe '.with_available_course' do
+    let(:order) { create(:order, :fulfilled) }
+    before do 
+      order
+      create(:order)
+    end
+    subject { Order.course_available }
+    
+    it { expect(subject.count).to be(1) }
+    it { expect(subject).to include(order) }
+
+  end
+  
+  describe '#fulfill!' do
+    subject { order }
+    before do
+      order.pay!
+      order.fulfill!
+    end
+
+    it { is_expected.to be_fulfilled }
+    it { is_expected.to be_course_available }
+    it { expect(subject.end_at).to be_present }
+  end
+  
+end


### PR DESCRIPTION
新增 `Orders::CheckoutForm` 
- 訂購課程流程
- 付款時產生 `payment`, 未來可在 `Payment#charge!` 中時做付款流程
- 訂購成功可以建立一筆 `order` 為 fulfilled 狀態
  - `fulfilled` 狀態的 order 一定會標註課程結束時間
- 驗證
  - 可以驗證如果 課程下架 ( `course.delisted`) 的時候無法購買
  - 可以驗證如果課程還可以瀏覽時，無法購買